### PR TITLE
Remove setuptools from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ requirements = [
     'google-cloud-core',
     'requests',
     'retrying',
-    'setuptools >= 25.0.0',
     'packaging',
     'pylint >= 1.8.0',
 ]


### PR DESCRIPTION
In newer Python 3.7/3.8+ systems built with a recent enough `setuptools` (>=47.2.0), console scripts are preferring `importlib.metadata` over `pkg_resources`. Since `setuptools` isn't used elsewhere in this project, it is no longer a dependency.